### PR TITLE
ドレミのド、がミになっていたのを修正

### DIFF
--- a/def.tsv
+++ b/def.tsv
@@ -67,7 +67,7 @@ mule	ラバ(家畜)|頑固者|雑種の動植物|つっかけ式スリッパ
 gitabit	ギガ(10^9)ビット
 scalable	拡張性のある
 electromagnetic	電磁力の
-doe	鹿,ウサギ,羊等の雌(反義語buck)|ドレミのミ(*,Ray,Me,Far,Sew,La,Tea)
+doe	鹿,ウサギ,羊等の雌(反義語buck)|ドレミのド(*,Ray,Me,Far,Sew,La,Tea)
 me	私を|私に|ドレミのミ(Doe,Ray,*,Far,Sew,La,Tea)
 sew	を縫う|縫い物をする|を縫い付ける|ドレミのソ(Doe,Ray,Me,Far,*,La,Tea)
 improper	不適切な|不道徳な|不規則な


### PR DESCRIPTION
間違いと思われる箇所がありましたので、お手すきの際にご確認いただけますと幸いです。
